### PR TITLE
feat(helper): add colorize transformation support and update tests

### DIFF
--- a/lib/helper.go
+++ b/lib/helper.go
@@ -403,6 +403,12 @@ func (r *HelperService) buildTransformationStringInternal(transformation []share
 				}
 				return "", false
 			}},
+			{"e-colorize", func() (string, bool) {
+				if value := r.getOptParamValue(currentTransform.Colorize); value != "" {
+					return value, false
+				}
+				return "", false
+			}},
 			{"e-distort", func() (string, bool) {
 				if value := r.getOptParamValue(currentTransform.Distort); value != "" {
 					return value, false

--- a/tests/helper_advanced_transformations_test.go
+++ b/tests/helper_advanced_transformations_test.go
@@ -526,6 +526,7 @@ func TestParameterSpecificTransformations(t *testing.T) {
 				},
 				// New transformations
 				ColorReplace: param.Opt[string]{Value: "FF0000_100_0000FF"},
+				Colorize:     param.Opt[string]{Value: "co-red_in-50"},
 				Distort:      param.Opt[string]{Value: "a-45"},
 				Original:     param.Opt[bool]{Value: true},
 				Page: shared.TransformationPageUnionParam{
@@ -542,7 +543,7 @@ func TestParameterSpecificTransformations(t *testing.T) {
 			Transformation:         transformation,
 		})
 
-		expected := "https://ik.imagekit.io/test_url_endpoint/test_path.jpg?tr=w-400,h-300,q-40,ar-4-3,c-force,cm-extract,fo-left,f-jpeg,r-50,bg-A94D34,b-5-A94D34,cr-FF0000_100_0000FF,di-folder@@file.jpg,dpr-3,x-10,y-20,xc-30,yc-40,o-0.8,z-2,rt-90,bl-10,n-some_name,pr-true,lo-true,fl-h,t-5,md-true,cp-true,vc-h264,ac-aac,so-5,eo-15,du-10,sr-1440_1080,e-grayscale,e-upscale,e-retouch,e-genvar,e-bgremove,e-contrast,e-dropshadow,e-changebg-prompt-car,e-edit-prompt-make it vintage,e-shadow-bl-15_st-40_x-10_y-N5,e-sharpen-10,e-usm-2-2-0.8-0.024,e-gradient-from-red_to-white,e-distort-a-45,orig-true,pg-2_4,h-200,w-300,l-image,i-logo.png,l-end"
+		expected := "https://ik.imagekit.io/test_url_endpoint/test_path.jpg?tr=w-400,h-300,q-40,ar-4-3,c-force,cm-extract,fo-left,f-jpeg,r-50,bg-A94D34,b-5-A94D34,cr-FF0000_100_0000FF,di-folder@@file.jpg,dpr-3,x-10,y-20,xc-30,yc-40,o-0.8,z-2,rt-90,bl-10,n-some_name,pr-true,lo-true,fl-h,t-5,md-true,cp-true,vc-h264,ac-aac,so-5,eo-15,du-10,sr-1440_1080,e-grayscale,e-upscale,e-retouch,e-genvar,e-bgremove,e-contrast,e-dropshadow,e-changebg-prompt-car,e-edit-prompt-make it vintage,e-shadow-bl-15_st-40_x-10_y-N5,e-sharpen-10,e-usm-2-2-0.8-0.024,e-gradient-from-red_to-white,e-colorize-co-red_in-50,e-distort-a-45,orig-true,pg-2_4,h-200,w-300,l-image,i-logo.png,l-end"
 		if url != expected {
 			t.Errorf("Expected %s, got %s", expected, url)
 		}


### PR DESCRIPTION
- Implemented the `colorize` transformation in the HelperService.
- Updated tests to include the new `colorize` parameter and verify its functionality in transformation URLs.


Test Results 

<img width="1143" height="476" alt="image" src="https://github.com/user-attachments/assets/33ebdb01-c11d-477a-b0cd-84a5bfd46c5e" />
